### PR TITLE
Fix profile image path separators

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -57,7 +57,7 @@
         <div class="container">
             <div class="row row-header">
                 <div class="col-12 col-sm-3">
-                    <img class="image-smaller image-border" src="img\profile_pic.jpg" alt="My profile pic">
+                    <img class="image-smaller image-border" src="img/profile_pic.jpg" alt="My profile pic">
                 </div>
                 <div class="col-12 col-sm-6">
                     <h1 class="handwriting jumbotron-text"><b>Matthias Chan</b></h1>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
         <div class="container">
             <div class="row row-header">
                 <div class="col-12 col-sm-3">
-                    <img class="img-fluid image-border" src="img\profile_pic.jpg" alt="My profile pic">
+                    <img class="img-fluid image-border" src="img/profile_pic.jpg" alt="My profile pic">
                 </div>
                 <div class="col-12 col-sm-6">
                     <h1 class="handwriting jumbotron-text"><b>Matthias Chan</b></h1>


### PR DESCRIPTION
## Summary
- use forward slashes for profile image references in pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895c84da044832fb640ee150a89c74e